### PR TITLE
fix: Post::$title must not be accessed before initialization #8

### DIFF
--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -7,10 +7,6 @@ use Illuminate\Database\Eloquent\Casts\Attribute;
 
 class Post extends Corcel
 {
-    public string $title;
-
-    public string $post_title;
-
     protected $connection = 'wordpress';
 
     protected $postType = 'post';


### PR DESCRIPTION
- fixed error on retrieved post title property